### PR TITLE
Prevent go's TabExpansion to overriding other TabExpansion implementations

### DIFF
--- a/go.psm1
+++ b/go.psm1
@@ -314,15 +314,24 @@
 }
 
 #------------------------------Tab Expansion------------------------------
-function TabExpansion($line, $lastWord) {
-  $LineBlocks = [regex]::Split($line, '[|;]')
-  $lastBlock = $LineBlocks[-1] 
- 
-  switch -regex ($lastBlock) {
-    'go (.*)' { goTabExpansion($lastBlock) }
-  }
+# Check if function TabExpansion already exists and backup existing version to
+# prevent breaking other TabExpansion implementations.
+# Taken from posh-git https://github.com/dahlbyk/posh-git/blob/master/GitTabExpansion.ps1#L297
+
+if (Test-Path Function:\TabExpansion) {
+    Rename-Item Function:\TabExpansion TabExpansionBackup
 }
 
+function TabExpansion($line, $lastWord) {
+    $lastBlock = [regex]::Split($line, '[|;]')[-1].TrimStart()
+
+    switch -regex ($lastBlock) {
+        # Execute go tab expansion for go command
+        '^go (.*)' { goTabExpansion($lastBlock) }
+        # Fall back on existing tab expansion
+        default { if (Test-Path Function:\TabExpansionBackup) { TabExpansionBackup $line $lastWord } }
+    }
+}
 function goTabExpansion($filter) {
     $textFilePath = "$([Environment]::GetFolderPath('LocalApplicationData'))\Go\go.txt"
     $textContent = Get-Content $textFilePath
@@ -354,3 +363,8 @@ function goTabExpansion($filter) {
         }
     }
 }
+
+# Explicitly export the functions to hide the TabExpansionBackup function if it exists
+Export-ModuleMember go
+Export-ModuleMember goTabExpansion
+Export-ModuleMember TabExpansion


### PR DESCRIPTION
Depending on the load order the go module did overwrite the TabExpansion of posh-git. To prevent go from override posh-git's TabExpansion, the function-backup-pattern like used in posh-git was added.
